### PR TITLE
Add React front-end mock for Saga storyboard flow

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,25 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: true
+    },
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
+  plugins: ['react', 'react-refresh'],
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off'
+  }
+};

--- a/README.md
+++ b/README.md
@@ -1,2 +1,92 @@
 # Saga
-Seniors biography
+
+Saga is a gentle, three-step web experience for older adults to upload cherished photos and notes so that the platform can shape them into a shareable storyboard. This project is a front-end mock built with React, Material UI, and Vite.
+
+## Features
+
+- **Accessible flow** with large typography and simple language tailored for older storytellers.
+- **Drag-and-drop uploader** for images with text guidance fields.
+- **Processing screen** that simulates AI generation with a five-second progress indicator.
+- **Storyboard summary** with downloadable JSON output that captures the generated scenes and notes.
+
+## Getting started locally
+
+1. Install dependencies:
+
+   ```bash
+   npm install
+   ```
+
+2. Start the development server:
+
+   ```bash
+   npm run dev
+   ```
+
+3. Open the printed local address in your browser to explore the experience.
+
+> **Note:** If package installation fails due to network restrictions, you can still review the source code, but the development server will require the dependencies listed in `package.json`.
+
+## Linting
+
+Run ESLint to check for code style issues:
+
+```bash
+npm run lint
+```
+
+## Building for production
+
+```bash
+npm run build
+```
+
+This outputs the static site to the `dist` directory.
+
+## Deploying to GitHub Pages
+
+The project is configured with `vite.config.js` to serve from a relative base path so it can be hosted from a repository root or a GitHub Pages project site.
+
+To deploy:
+
+1. If you haven't already, enable GitHub Pages for the repository (Settings → Pages → Build and deployment → GitHub Actions or Deploy from a branch).
+2. Build the project locally:
+
+   ```bash
+   npm run build
+   ```
+
+3. Commit and push the contents of the `dist` folder to the branch GitHub Pages serves from (for example, the `gh-pages` branch). You can automate this with the official `peaceiris/actions-gh-pages` GitHub Action. A minimal workflow is shown below:
+
+   ```yaml
+   name: Deploy Saga storyboard mock
+
+   on:
+     push:
+       branches:
+         - main
+
+   jobs:
+     build-and-deploy:
+       runs-on: ubuntu-latest
+
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-node@v4
+           with:
+             node-version: '20'
+         - run: npm install
+         - run: npm run build
+         - uses: peaceiris/actions-gh-pages@v4
+           with:
+             github_token: ${{ secrets.GITHUB_TOKEN }}
+             publish_dir: ./dist
+   ```
+
+   This workflow builds the site on every push to `main` and publishes it to the `gh-pages` branch automatically.
+
+4. After the workflow completes (or after you manually push the `dist` folder), visit the GitHub Pages URL shown in the repository settings to view Saga online.
+
+## License
+
+This project is licensed under the MIT License.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Saga - Storyboard Maker</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "saga",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "lint": "eslint ."
+  },
+  "dependencies": {
+    "@emotion/react": "^11.13.0",
+    "@emotion/styled": "^11.13.0",
+    "@mui/icons-material": "^5.15.20",
+    "@mui/material": "^5.15.20",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-dropzone": "^14.2.3",
+    "react-router-dom": "^6.26.2"
+  },
+  "devDependencies": {
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "eslint": "^8.57.0",
+    "eslint-plugin-react": "^7.37.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.6",
+    "vite": "^5.4.1"
+  }
+}

--- a/public/favicon.svg
+++ b/public/favicon.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <defs>
+    <linearGradient id="gradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#4a6da7" />
+      <stop offset="100%" stop-color="#f8a26c" />
+    </linearGradient>
+  </defs>
+  <rect width="100" height="100" rx="20" fill="url(#gradient)" />
+  <path
+    d="M30 70 L30 30 L55 30 Q70 30 70 45 Q70 55 60 60 L75 70"
+    fill="none"
+    stroke="#fff"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,119 @@
+import { useMemo, useState } from 'react';
+import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
+import { AppBar, Box, Container, Step, StepLabel, Stepper, Toolbar, Typography } from '@mui/material';
+import UploadPage from './pages/UploadPage.jsx';
+import ProcessingPage from './pages/ProcessingPage.jsx';
+import StoryboardPage from './pages/StoryboardPage.jsx';
+
+const steps = ['Upload memories', 'Processing', 'Storyboard'];
+
+function SagaLayout({ children }) {
+  const location = useLocation();
+  const activeStep = useMemo(() => {
+    if (location.pathname.startsWith('/processing')) return 1;
+    if (location.pathname.startsWith('/storyboard')) return 2;
+    return 0;
+  }, [location.pathname]);
+
+  return (
+    <Box sx={{ minHeight: '100vh', bgcolor: 'background.default' }}>
+      <AppBar position="static" color="primary" elevation={0}>
+        <Toolbar sx={{ justifyContent: 'center' }}>
+          <Typography variant="h5" component="div" sx={{ fontWeight: 600 }}>
+            Saga
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <Container maxWidth="md" sx={{ py: { xs: 4, md: 6 } }}>
+        <Box sx={{ mb: { xs: 4, md: 6 } }}>
+          <Stepper activeStep={activeStep} alternativeLabel>
+            {steps.map((label) => (
+              <Step key={label}>
+                <StepLabel>{label}</StepLabel>
+              </Step>
+            ))}
+          </Stepper>
+        </Box>
+        {children}
+      </Container>
+    </Box>
+  );
+}
+
+function SagaRouter() {
+  const [uploadData, setUploadData] = useState(null);
+  const [storyboard, setStoryboard] = useState(null);
+  const navigate = useNavigate();
+
+  const handleUpload = (data) => {
+    setUploadData(data);
+    setStoryboard(null);
+    navigate('/processing');
+  };
+
+  const handleProcessingComplete = () => {
+    if (!uploadData) {
+      navigate('/');
+      return;
+    }
+
+    const storyScenes = uploadData.files.map((file, index) => ({
+      id: index + 1,
+      title: `Scene ${index + 1}`,
+      description: uploadData.prompt || `Moment captured from ${file.name}`,
+      imageName: file.name
+    }));
+
+    const generatedStoryboard = {
+      title: uploadData.title || 'Saga Storyboard',
+      summary:
+        uploadData.summary ||
+        'A heartfelt recollection of treasured memories, arranged for easy sharing with loved ones.',
+      scenes: storyScenes.length
+        ? storyScenes
+        : [
+            {
+              id: 1,
+              title: 'Scene 1',
+              description:
+                'Your story will appear here once we have images or text to guide the storyboard.',
+              imageName: 'Placeholder image'
+            }
+          ]
+    };
+
+    setStoryboard(generatedStoryboard);
+    navigate('/storyboard');
+  };
+
+  return (
+    <Routes>
+      <Route path="/" element={<UploadPage onSubmit={handleUpload} />} />
+      <Route
+        path="/processing"
+        element={<ProcessingPage uploadData={uploadData} onComplete={handleProcessingComplete} />}
+      />
+      <Route
+        path="/storyboard"
+        element={
+          storyboard ? (
+            <StoryboardPage storyboard={storyboard} uploadData={uploadData} />
+          ) : (
+            <Navigate to="/" replace />
+          )
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  );
+}
+
+export default function App() {
+  return (
+    <BrowserRouter>
+      <SagaLayout>
+        <SagaRouter />
+      </SagaLayout>
+    </BrowserRouter>
+  );
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+import App from './App.jsx';
+
+const theme = createTheme({
+  palette: {
+    mode: 'light',
+    primary: {
+      main: '#4a6da7'
+    },
+    secondary: {
+      main: '#f8a26c'
+    },
+    background: {
+      default: '#f5f6fa',
+      paper: '#ffffff'
+    }
+  },
+  typography: {
+    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+    h3: {
+      fontWeight: 600
+    },
+    button: {
+      textTransform: 'none',
+      fontSize: '1rem'
+    }
+  }
+});
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>
+);

--- a/src/pages/ProcessingPage.jsx
+++ b/src/pages/ProcessingPage.jsx
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react';
+import { Box, Button, Card, CardContent, LinearProgress, Stack, Typography } from '@mui/material';
+import HourglassBottomIcon from '@mui/icons-material/HourglassBottom';
+import { useNavigate } from 'react-router-dom';
+
+const PROCESS_DURATION = 5000;
+
+export default function ProcessingPage({ uploadData, onComplete }) {
+  const navigate = useNavigate();
+  const [progress, setProgress] = useState(0);
+
+  useEffect(() => {
+    if (!uploadData) {
+      navigate('/', { replace: true });
+      return;
+    }
+
+    let start;
+    let animationFrame;
+
+    const updateProgress = (timestamp) => {
+      if (!start) start = timestamp;
+      const elapsed = timestamp - start;
+      const percentage = Math.min(100, Math.round((elapsed / PROCESS_DURATION) * 100));
+      setProgress(percentage);
+
+      if (elapsed < PROCESS_DURATION) {
+        animationFrame = requestAnimationFrame(updateProgress);
+      } else {
+        onComplete();
+      }
+    };
+
+    animationFrame = requestAnimationFrame(updateProgress);
+
+    return () => cancelAnimationFrame(animationFrame);
+  }, [navigate, onComplete, uploadData]);
+
+  if (!uploadData) {
+    return null;
+  }
+
+  return (
+    <Stack spacing={4} alignItems="center">
+      <Box textAlign="center">
+        <Typography variant="h3" gutterBottom>
+          Creating your storyboard
+        </Typography>
+        <Typography variant="h6" color="text.secondary">
+          Please hold tight while we weave together your memories. This should only take a few moments.
+        </Typography>
+      </Box>
+
+      <Card variant="outlined" sx={{ width: '100%' }}>
+        <CardContent>
+          <Stack spacing={3} alignItems="center">
+            <HourglassBottomIcon color="primary" sx={{ fontSize: 56 }} />
+            <LinearProgress variant="determinate" value={progress} sx={{ width: '100%', height: 12, borderRadius: 6 }} />
+            <Typography variant="h6">{progress}% complete</Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Button variant="text" onClick={() => navigate('/')}>
+        Go back to start
+      </Button>
+    </Stack>
+  );
+}

--- a/src/pages/StoryboardPage.jsx
+++ b/src/pages/StoryboardPage.jsx
@@ -1,0 +1,129 @@
+import { useMemo } from 'react';
+import {
+  Box,
+  Button,
+  Card,
+  CardActions,
+  CardContent,
+  Divider,
+  Grid,
+  Stack,
+  Typography
+} from '@mui/material';
+import DownloadIcon from '@mui/icons-material/Download';
+import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import { useNavigate } from 'react-router-dom';
+
+function downloadStoryboard(storyboard, uploadData) {
+  const documentContent = {
+    generatedAt: new Date().toISOString(),
+    title: storyboard.title,
+    summary: storyboard.summary,
+    guidance: uploadData?.prompt || '',
+    scenes: storyboard.scenes
+  };
+
+  const blob = new Blob([JSON.stringify(documentContent, null, 2)], {
+    type: 'application/json'
+  });
+
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${storyboard.title.replace(/\s+/g, '-').toLowerCase()}-storyboard.json`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export default function StoryboardPage({ storyboard, uploadData }) {
+  const navigate = useNavigate();
+
+  const sceneGrid = useMemo(
+    () =>
+      storyboard.scenes.map((scene) => (
+        <Grid item xs={12} sm={6} key={scene.id}>
+          <Card variant="outlined" sx={{ height: '100%' }}>
+            <CardContent>
+              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
+                {scene.imageName}
+              </Typography>
+              <Typography variant="h6" gutterBottom>
+                {scene.title}
+              </Typography>
+              <Typography color="text.secondary">{scene.description}</Typography>
+            </CardContent>
+          </Card>
+        </Grid>
+      )),
+    [storyboard.scenes]
+  );
+
+  return (
+    <Stack spacing={4}>
+      <Box>
+        <Typography variant="h3" gutterBottom>
+          {storyboard.title}
+        </Typography>
+        <Typography variant="h6" color="text.secondary">
+          {storyboard.summary}
+        </Typography>
+      </Box>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={2}>
+            <Typography variant="subtitle1" color="text.secondary">
+              Story guidance
+            </Typography>
+            <Typography>
+              {uploadData?.prompt
+                ? uploadData.prompt
+                : 'We used your notes and photos to organize the storyboard below.'}
+            </Typography>
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Box>
+        <Typography variant="h5" gutterBottom>
+          Scenes
+        </Typography>
+        <Grid container spacing={3}>
+          {sceneGrid}
+        </Grid>
+      </Box>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={2}>
+            <Typography variant="subtitle1" color="text.secondary">
+              Next steps
+            </Typography>
+            <Typography>
+              Download the storyboard summary to save or share with family members. You can restart to make changes anytime.
+            </Typography>
+          </Stack>
+        </CardContent>
+        <Divider />
+        <CardActions sx={{ justifyContent: { xs: 'center', sm: 'space-between' }, flexWrap: 'wrap', gap: 2, p: 3 }}>
+          <Button
+            variant="contained"
+            startIcon={<DownloadIcon />}
+            onClick={() => downloadStoryboard(storyboard, uploadData)}
+          >
+            Download storyboard
+          </Button>
+          <Button
+            variant="outlined"
+            startIcon={<RestartAltIcon />}
+            onClick={() => navigate('/')}
+          >
+            Start a new storyboard
+          </Button>
+        </CardActions>
+      </Card>
+    </Stack>
+  );
+}

--- a/src/pages/UploadPage.jsx
+++ b/src/pages/UploadPage.jsx
@@ -1,0 +1,173 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Stack,
+  TextField,
+  Typography
+} from '@mui/material';
+import { useDropzone } from 'react-dropzone';
+import CloudUploadIcon from '@mui/icons-material/CloudUpload';
+
+const MAX_FILES = 12;
+
+export default function UploadPage({ onSubmit }) {
+  const [files, setFiles] = useState([]);
+  const [title, setTitle] = useState('');
+  const [summary, setSummary] = useState('');
+  const [prompt, setPrompt] = useState('');
+  const [error, setError] = useState('');
+
+  const onDrop = useCallback((acceptedFiles) => {
+    const newFiles = [...files, ...acceptedFiles].slice(0, MAX_FILES);
+    setFiles(newFiles);
+    if (files.length + acceptedFiles.length > MAX_FILES) {
+      setError(`You can add up to ${MAX_FILES} files for a single storyboard.`);
+    } else {
+      setError('');
+    }
+  }, [files]);
+
+  const { getRootProps, getInputProps, isDragActive } = useDropzone({
+    onDrop,
+    accept: {
+      'image/*': []
+    }
+  });
+
+  const filePreviews = useMemo(
+    () =>
+      files.map((file) => ({
+        name: file.name,
+        size: file.size
+      })),
+    [files]
+  );
+
+  const handleSubmit = (event) => {
+    event.preventDefault();
+    if (!files.length && !summary && !prompt) {
+      setError('Please add at least one image or a short note to get started.');
+      return;
+    }
+
+    onSubmit({
+      files,
+      title,
+      summary,
+      prompt
+    });
+  };
+
+  const handleClearFiles = () => {
+    setFiles([]);
+    setError('');
+  };
+
+  return (
+    <Stack spacing={4} component="form" onSubmit={handleSubmit}>
+      <Box>
+        <Typography variant="h3" gutterBottom>
+          Welcome to Saga
+        </Typography>
+        <Typography variant="h6" color="text.secondary">
+          Gather photos and notes from loved ones and let Saga create a storyboard that is easy to share.
+        </Typography>
+      </Box>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={3}>
+            <Box
+              {...getRootProps()}
+              sx={{
+                border: '2px dashed',
+                borderColor: isDragActive ? 'primary.main' : 'grey.400',
+                borderRadius: 2,
+                bgcolor: isDragActive ? 'primary.50' : 'grey.50',
+                p: 5,
+                textAlign: 'center',
+                cursor: 'pointer'
+              }}
+            >
+              <input {...getInputProps()} />
+              <CloudUploadIcon color="primary" sx={{ fontSize: 48, mb: 2 }} />
+              <Typography variant="h6" gutterBottom>
+                {isDragActive ? 'Drop the files here' : 'Drag and drop images or click to choose'}
+              </Typography>
+              <Typography color="text.secondary">
+                Accepted formats: JPG, PNG, GIF. Up to {MAX_FILES} images.
+              </Typography>
+            </Box>
+
+            {filePreviews.length > 0 && (
+              <Stack spacing={1}>
+                <Typography variant="subtitle1">Selected images</Typography>
+                <Stack spacing={1} sx={{ maxHeight: 200, overflow: 'auto', pr: 1 }}>
+                  {filePreviews.map((file) => (
+                    <Box
+                      key={file.name}
+                      sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}
+                    >
+                      <Typography>{file.name}</Typography>
+                      <Typography variant="body2" color="text.secondary">
+                        {(file.size / 1024).toFixed(1)} KB
+                      </Typography>
+                    </Box>
+                  ))}
+                </Stack>
+                <Box>
+                  <Button color="secondary" onClick={handleClearFiles}>
+                    Clear images
+                  </Button>
+                </Box>
+              </Stack>
+            )}
+          </Stack>
+        </CardContent>
+      </Card>
+
+      <Card variant="outlined">
+        <CardContent>
+          <Stack spacing={3}>
+            <TextField
+              label="Story title (optional)"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              fullWidth
+            />
+            <TextField
+              label="Short description"
+              value={summary}
+              onChange={(event) => setSummary(event.target.value)}
+              fullWidth
+              multiline
+              minRows={3}
+              helperText="Share the essence of this memory in a few sentences."
+            />
+            <TextField
+              label="Extra guidance for the storyboard"
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              fullWidth
+              multiline
+              minRows={4}
+              helperText="Add names, locations, or special notes you would like highlighted."
+            />
+          </Stack>
+        </CardContent>
+      </Card>
+
+      {error && <Alert severity="warning">{error}</Alert>}
+
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+        <Button type="submit" variant="contained" size="large">
+          Start processing
+        </Button>
+      </Box>
+    </Stack>
+  );
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  base: './'
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite + React single-page app with Material UI styling for the Saga storyboard experience
- implement upload, processing, and storyboard views with mocked data flow and downloadable summary output
- document local development and GitHub Pages deployment steps in the README

## Testing
- not run (npm install blocked by registry access restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68dc82db93b08327b433e864c4038a34