### PR TITLE
Render storyboard with heartfelt imagery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { BrowserRouter, Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AppBar, Box, Container, Step, StepLabel, Stepper, Toolbar, Typography } from '@mui/material';
 import UploadPage from './pages/UploadPage.jsx';
@@ -57,34 +57,89 @@ function SagaRouter() {
       return;
     }
 
-    const storyScenes = uploadData.files.map((file, index) => ({
-      id: index + 1,
-      title: `Scene ${index + 1}`,
-      description: uploadData.prompt || `Moment captured from ${file.name}`,
-      imageName: file.name
-    }));
+    const generateSceneTitle = (fileName, index) => {
+      if (!fileName) {
+        return `Scene ${index + 1}`;
+      }
+
+      const baseName = fileName.replace(/\.[^/.]+$/, '').replace(/[-_]+/g, ' ');
+      const formatted = baseName.charAt(0).toUpperCase() + baseName.slice(1);
+      return formatted || `Scene ${index + 1}`;
+    };
+
+    const promptText = uploadData.prompt?.trim();
+    const summaryText = uploadData.summary?.trim();
+
+    const storyScenes = uploadData.files.map((file, index) => {
+      const objectUrl = URL.createObjectURL(file);
+      return {
+        id: index + 1,
+        title: generateSceneTitle(file.name, index),
+        description:
+          promptText ||
+          (summaryText
+            ? `${summaryText} — captured through ${file.name}`
+            : 'A treasured memory shared together.'),
+        imageName: file.name,
+        imageUrl: objectUrl,
+        isObjectUrl: true
+      };
+    });
+
+    const stockImageUrl =
+      'https://images.unsplash.com/photo-1525610553991-2bede1a236e2?auto=format&fit=crop&w=1000&q=80';
 
     const generatedStoryboard = {
       title: uploadData.title || 'Saga Storyboard',
       summary:
         uploadData.summary ||
         'A heartfelt recollection of treasured memories, arranged for easy sharing with loved ones.',
-      scenes: storyScenes.length
-        ? storyScenes
-        : [
-            {
-              id: 1,
-              title: 'Scene 1',
-              description:
-                'Your story will appear here once we have images or text to guide the storyboard.',
-              imageName: 'Placeholder image'
-            }
-          ]
+      scenes:
+        storyScenes.length > 0
+          ? storyScenes
+          : [
+              {
+                id: 1,
+                title: 'A cherished beginning',
+                description:
+                  summaryText ||
+                  'We imagine the gentle start of this memory — a warm gathering filled with smiles.',
+                imageName: 'Stock family photo',
+                imageUrl: stockImageUrl
+              },
+              {
+                id: 2,
+                title: 'Shared laughter',
+                description:
+                  promptText ||
+                  'In our storyboard, everyone leans in close, sharing stories and laughter across generations.',
+                imageName: 'Stock family photo',
+                imageUrl: stockImageUrl
+              },
+              {
+                id: 3,
+                title: 'Legacy of love',
+                description:
+                  'The closing scene celebrates the wisdom and love that continue to guide the family forward.',
+                imageName: 'Stock family photo',
+                imageUrl: stockImageUrl
+              }
+            ]
     };
 
     setStoryboard(generatedStoryboard);
     navigate('/storyboard');
   };
+
+  useEffect(() => {
+    return () => {
+      storyboard?.scenes?.forEach((scene) => {
+        if (scene.isObjectUrl && scene.imageUrl) {
+          URL.revokeObjectURL(scene.imageUrl);
+        }
+      });
+    };
+  }, [storyboard]);
 
   return (
     <Routes>

--- a/src/pages/StoryboardPage.jsx
+++ b/src/pages/StoryboardPage.jsx
@@ -5,6 +5,7 @@ import {
   Card,
   CardActions,
   CardContent,
+  CardMedia,
   Divider,
   Grid,
   Stack,
@@ -39,20 +40,44 @@ function downloadStoryboard(storyboard, uploadData) {
 
 export default function StoryboardPage({ storyboard, uploadData }) {
   const navigate = useNavigate();
+  const fallbackHeroImage =
+    'https://images.unsplash.com/photo-1525610553991-2bede1a236e2?auto=format&fit=crop&w=1200&q=80';
 
   const sceneGrid = useMemo(
     () =>
-      storyboard.scenes.map((scene) => (
+      storyboard.scenes.map((scene, index) => (
         <Grid item xs={12} sm={6} key={scene.id}>
-          <Card variant="outlined" sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                {scene.imageName}
+          <Card
+            variant="outlined"
+            sx={{
+              height: '100%',
+              display: 'flex',
+              flexDirection: 'column',
+              overflow: 'hidden'
+            }}
+          >
+            <CardMedia
+              component="img"
+              image={scene.imageUrl || fallbackHeroImage}
+              alt={scene.imageName || scene.title}
+              sx={{
+                height: 240,
+                objectFit: 'cover'
+              }}
+            />
+            <CardContent sx={{ flexGrow: 1 }}>
+              <Typography variant="subtitle2" color="primary" gutterBottom>
+                Scene {index + 1}
               </Typography>
               <Typography variant="h6" gutterBottom>
                 {scene.title}
               </Typography>
               <Typography color="text.secondary">{scene.description}</Typography>
+              {scene.imageName && (
+                <Typography variant="caption" color="text.secondary" display="block" sx={{ mt: 2 }}>
+                  From: {scene.imageName}
+                </Typography>
+              )}
             </CardContent>
           </Card>
         </Grid>
@@ -60,15 +85,35 @@ export default function StoryboardPage({ storyboard, uploadData }) {
     [storyboard.scenes]
   );
 
+  const primaryScene = storyboard.scenes[0];
+  const heroImage = primaryScene?.imageUrl || fallbackHeroImage;
+
   return (
     <Stack spacing={4}>
-      <Box>
-        <Typography variant="h3" gutterBottom>
-          {storyboard.title}
-        </Typography>
-        <Typography variant="h6" color="text.secondary">
-          {storyboard.summary}
-        </Typography>
+      <Box
+        sx={{
+          position: 'relative',
+          borderRadius: 4,
+          overflow: 'hidden',
+          minHeight: { xs: 260, md: 320 },
+          backgroundImage: `linear-gradient(rgba(17, 24, 39, 0.4), rgba(17, 24, 39, 0.6)), url(${heroImage})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          color: 'common.white'
+        }}
+      >
+        <Box sx={{ position: 'absolute', inset: 0, bgcolor: 'rgba(17, 24, 39, 0.35)' }} />
+        <Stack spacing={2} sx={{ position: 'relative', p: { xs: 4, md: 6 }, maxWidth: 520 }}>
+          <Typography variant="overline" sx={{ letterSpacing: 1.2 }}>
+            Storyboard
+          </Typography>
+          <Typography variant="h3" component="h1">
+            {storyboard.title}
+          </Typography>
+          <Typography variant="h6" component="p">
+            {storyboard.summary}
+          </Typography>
+        </Stack>
       </Box>
 
       <Card variant="outlined">


### PR DESCRIPTION
## Summary
- generate storyboard scenes with image URLs, heartfelt fallback text, and cleanup for object URLs
- redesign the storyboard page to feature a hero image and scene cards with photos and descriptions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df47dba6508327adaeda445bf566cb