### PR TITLE
Introduce storyboard moment carousel

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Saga is a gentle, three-step web experience for older adults to upload cherished
 - **Accessible flow** with large typography and simple language tailored for older storytellers.
 - **Drag-and-drop uploader** for images with text guidance fields.
 - **Processing screen** that simulates AI generation with a five-second progress indicator.
-- **Storyboard summary** with downloadable JSON output that captures the generated scenes and notes.
+- **Storyboard summary** with downloadable JSON output that captures the generated moments and notes.
 
 ## Getting started locally
 

--- a/src/pages/StoryboardPage.jsx
+++ b/src/pages/StoryboardPage.jsx
@@ -1,17 +1,21 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Box,
   Button,
   Card,
   CardActions,
   CardContent,
+  CardMedia,
   Divider,
   Grid,
+  MobileStepper,
   Stack,
   Typography
 } from '@mui/material';
 import DownloadIcon from '@mui/icons-material/Download';
 import RestartAltIcon from '@mui/icons-material/RestartAlt';
+import KeyboardArrowLeft from '@mui/icons-material/KeyboardArrowLeft';
+import KeyboardArrowRight from '@mui/icons-material/KeyboardArrowRight';
 import { useNavigate } from 'react-router-dom';
 
 function downloadStoryboard(storyboard, uploadData) {
@@ -20,7 +24,7 @@ function downloadStoryboard(storyboard, uploadData) {
     title: storyboard.title,
     summary: storyboard.summary,
     guidance: uploadData?.prompt || '',
-    scenes: storyboard.scenes
+    moments: storyboard.moments
   };
 
   const blob = new Blob([JSON.stringify(documentContent, null, 2)], {
@@ -39,36 +43,56 @@ function downloadStoryboard(storyboard, uploadData) {
 
 export default function StoryboardPage({ storyboard, uploadData }) {
   const navigate = useNavigate();
+  const fallbackHeroImage =
+    'https://images.unsplash.com/photo-1525610553991-2bede1a236e2?auto=format&fit=crop&w=1200&q=80';
 
-  const sceneGrid = useMemo(
-    () =>
-      storyboard.scenes.map((scene) => (
-        <Grid item xs={12} sm={6} key={scene.id}>
-          <Card variant="outlined" sx={{ height: '100%' }}>
-            <CardContent>
-              <Typography variant="subtitle2" color="text.secondary" gutterBottom>
-                {scene.imageName}
-              </Typography>
-              <Typography variant="h6" gutterBottom>
-                {scene.title}
-              </Typography>
-              <Typography color="text.secondary">{scene.description}</Typography>
-            </CardContent>
-          </Card>
-        </Grid>
-      )),
-    [storyboard.scenes]
-  );
+  const moments = useMemo(() => storyboard.moments ?? [], [storyboard.moments]);
+  const [activeMomentIndex, setActiveMomentIndex] = useState(0);
+
+  useEffect(() => {
+    setActiveMomentIndex(0);
+  }, [moments.length]);
+
+  const totalMoments = moments.length;
+  const activeMoment = moments[activeMomentIndex] || null;
+  const heroImage = activeMoment?.imageUrl || fallbackHeroImage;
+
+  const handleNext = () => {
+    if (!totalMoments) return;
+    setActiveMomentIndex((prev) => (prev + 1) % totalMoments);
+  };
+
+  const handleBack = () => {
+    if (!totalMoments) return;
+    setActiveMomentIndex((prev) => (prev - 1 + totalMoments) % totalMoments);
+  };
 
   return (
     <Stack spacing={4}>
-      <Box>
-        <Typography variant="h3" gutterBottom>
-          {storyboard.title}
-        </Typography>
-        <Typography variant="h6" color="text.secondary">
-          {storyboard.summary}
-        </Typography>
+      <Box
+        sx={{
+          position: 'relative',
+          borderRadius: 4,
+          overflow: 'hidden',
+          minHeight: { xs: 260, md: 320 },
+          backgroundImage: `linear-gradient(rgba(17, 24, 39, 0.4), rgba(17, 24, 39, 0.6)), url(${heroImage})`,
+          backgroundSize: 'cover',
+          backgroundPosition: 'center',
+          color: 'common.white'
+        }}
+      >
+        <Box sx={{ position: 'absolute', inset: 0, bgcolor: 'rgba(17, 24, 39, 0.35)' }} />
+        <Stack spacing={2} sx={{ position: 'relative', p: { xs: 4, md: 6 }, maxWidth: 520 }}>
+          <Typography variant="overline" sx={{ letterSpacing: 1.2 }}>
+            Storyboard
+          </Typography>
+          <Typography variant="h3" component="h1">
+            {storyboard.title}
+          </Typography>
+          <Typography variant="h6" component="p">
+            {storyboard.summary}
+          </Typography>
+        </Stack>
       </Box>
 
       <Card variant="outlined">
@@ -88,11 +112,71 @@ export default function StoryboardPage({ storyboard, uploadData }) {
 
       <Box>
         <Typography variant="h5" gutterBottom>
-          Scenes
+          Story moments
         </Typography>
-        <Grid container spacing={3}>
-          {sceneGrid}
-        </Grid>
+        {totalMoments > 0 ? (
+          <Grid container spacing={3} justifyContent="center">
+            <Grid item xs={12} md={10}>
+              <Card
+                variant="outlined"
+                sx={{ display: 'flex', flexDirection: 'column', overflow: 'hidden' }}
+              >
+                <CardMedia
+                  component="img"
+                  image={activeMoment?.imageUrl || fallbackHeroImage}
+                  alt={activeMoment?.imageName || activeMoment?.title || storyboard.title}
+                  sx={{
+                    height: { xs: 260, sm: 320 },
+                    objectFit: 'cover'
+                  }}
+                />
+                <CardContent>
+                  <Stack spacing={1.5}>
+                    <Typography variant="subtitle2" color="primary">
+                      Moment {activeMomentIndex + 1} of {totalMoments}
+                    </Typography>
+                    <Typography variant="h5" component="h2">
+                      {activeMoment?.title}
+                    </Typography>
+                    <Typography color="text.secondary">
+                      {activeMoment?.description}
+                    </Typography>
+                    {activeMoment?.imageName && (
+                      <Typography variant="caption" color="text.secondary" display="block">
+                        From: {activeMoment.imageName}
+                      </Typography>
+                    )}
+                  </Stack>
+                </CardContent>
+                <MobileStepper
+                  variant="dots"
+                  steps={totalMoments}
+                  position="static"
+                  activeStep={activeMomentIndex}
+                  sx={{ px: 3, pb: 2 }}
+                  backButton={
+                    <Button onClick={handleBack} size="small" startIcon={<KeyboardArrowLeft />}>
+                      Previous
+                    </Button>
+                  }
+                  nextButton={
+                    <Button onClick={handleNext} size="small" endIcon={<KeyboardArrowRight />}>
+                      Next
+                    </Button>
+                  }
+                />
+              </Card>
+            </Grid>
+          </Grid>
+        ) : (
+          <Card variant="outlined">
+            <CardContent>
+              <Typography color="text.secondary">
+                Your storyboard moments will appear here once memories are added.
+              </Typography>
+            </CardContent>
+          </Card>
+        )}
       </Box>
 
       <Card variant="outlined">


### PR DESCRIPTION
## Summary
- rename storyboard scenes to moments across the app and exported JSON
- present story moments in a single-card carousel with navigation controls
- sync the hero image with the active moment and keep fallback messaging for empty boards

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df47dba6508327adaeda445bf566cb